### PR TITLE
Add module dependency for cli-color

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "express": "3.0.3",
     "jade": "*",
     "less-middleware": "*",
-    "html2jade": "*"
+    "html2jade": "*",
+    "cli-color": "*"
   }
 }


### PR DESCRIPTION
It seems to be missing the cli-color module dependency in the current package.json.
